### PR TITLE
Install rsync to allow use of ansible syncronize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apt -y install gnupg2
 # Install Ansible
 RUN apt -y install ansible
 
+# Install Rsync to allow use of ansible.posix.synchronise
+RUN apt -y install rsync
+
 # Install Packer (jq for parsing manifest files)
 RUN apt -y install wget unzip curl jq
 RUN if [ $(uname -m) = "x86_64" ]; then curl "https://releases.hashicorp.com/packer/${packer_version}/packer_${packer_version}_linux_amd64.zip" -o "packer.zip"; elif [ $(uname -m) = "aarch64" ]; then curl "https://releases.hashicorp.com/packer/${packer_version}/packer_${packer_version}_linux_arm64.zip" -o "packer.zip"; fi


### PR DESCRIPTION
Rsync is required for the syncronize module to work

Fixes errors like this:

fatal: [default]: FAILED! => {"changed": false, "msg": "Failed to find required executable rsync in paths:

when attempting to sync directores

 https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html#notes